### PR TITLE
Fixed Norwegian Nordnet detection

### DIFF
--- a/js/uploadcontrol.js
+++ b/js/uploadcontrol.js
@@ -119,7 +119,7 @@ define(['./papaparse.min', './appcontrolhandler', './alasqlavanza', './alasqlnor
                     alasql('INSERT INTO Portfolio SELECT DISTINCT Konto FROM CSV(?, {separator:";"})', [readerResultString]);
                 }                    
                 else {
-                    var isFileNordnetNorway = readerResultString.startsWith("Id;Bokføringsdag;Handelsdag");
+                    var isFileNordnetNorway = readerResultString.startsWith("Id\tBokføringsdag\tHandelsdag");
                     
                     if(isFileNordnetNorway) {
                         applocalization.loadLanguage("no");


### PR DESCRIPTION
According to the Papa Parse documentation so does it autoguess for CSV delimiters in the following order: ',', '\t', '|', ';', Papa.RECORD_SEP, Papa.UNIT_SEP

This means that there should be no need to specify the new delimiter (\t) used by Nordnet.